### PR TITLE
TY-2896 update rust toolchain to 1.61.0

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 env:
-  RUST_NIGHTLY: nightly-2021-09-09
+  RUST_NIGHTLY: nightly-2022-05-19
   RUST_WORKSPACE: ${{ github.workspace }}/
   RUSTFLAGS: "-D warnings"
   DISABLE_AUTO_DART_FFIGEN: 1

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.55.0"
+channel = "1.61.0"
 profile = "default"


### PR DESCRIPTION
**References**

- [TY-2896]
- https://github.com/xaynetwork/xayn_discovery_engine/pull/427
- https://github.com/xaynetwork/xayn_async_bindgen/pull/16

**Summary**

- update toolchain versions
