### PR TITLE
TY-2908 update dart/flutter toolchain to 2.17.3/3.0.2

### DIFF
--- a/.github/workflows/integration_tests_ci.yml
+++ b/.github/workflows/integration_tests_ci.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 env:
-  DART_VERSION: '2.14.4'
+  DART_VERSION: '2.17.3'
   DART_WORKSPACE: ${{ github.workspace }}/integration_tests
   RUST_WORKSPACE: ${{ github.workspace }}/
 

--- a/integration_tests/pubspec.lock
+++ b/integration_tests/pubspec.lock
@@ -359,4 +359,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.4 <3.0.0"
+  dart: ">=2.17.3 <3.0.0"

--- a/integration_tests/pubspec.yaml
+++ b/integration_tests/pubspec.yaml
@@ -3,7 +3,7 @@ description: A starting point for Dart libraries or applications.
 version: 0.1.0
 
 environment:
-  sdk: '>=2.14.4 <3.0.0'
+  sdk: '>=2.17.3 <3.0.0'
 
 dev_dependencies:
   lints: ^1.0.1

--- a/integration_tests/test/integration_tests_test.dart
+++ b/integration_tests/test/integration_tests_test.dart
@@ -49,17 +49,12 @@ Future<void> main() async {
     );
   });
 
-  test(
-    'send TransferTypedData to rust',
-    () async {
-      final data = TransferableTypedData.fromList([
-        Uint8List.fromList([33, 44, 12, 123])
-      ]);
-      await Commander.sendCmd('recv ttd', [data]);
-    },
-    // Crashes in dart 2.14.4
-    skip: true,
-  );
+  test('send TransferTypedData to rust', () async {
+    final data = TransferableTypedData.fromList([
+      Uint8List.fromList([33, 44, 12, 123])
+    ]);
+    await Commander.sendCmd('recv ttd', [data]);
+  });
 
   test('panic catching works', () async {
     final dynamic res = await Commander.sendCmd('panic');


### PR DESCRIPTION
**References**

- [TY-2908]
- https://github.com/xaynetwork/xayn_discovery_engine/pull/446
- https://github.com/xaynetwork/xayn_async_bindgen/pull/17

**Summary**

- update toolchain versions
- enable previously disabled test
