### PR TITLE
TY-3100 update rust toolchain 1.62.1

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 env:
-  RUST_NIGHTLY: nightly-2022-05-19
+  RUST_NIGHTLY: nightly-2022-07-16
   RUST_WORKSPACE: ${{ github.workspace }}/
   RUSTFLAGS: "-D warnings"
   DISABLE_AUTO_DART_FFIGEN: 1

--- a/dart-api-dl-sys/Cargo.toml
+++ b/dart-api-dl-sys/Cargo.toml
@@ -11,4 +11,4 @@ static_assertions = "1.1.0"
 [build-dependencies]
 bindgen = "0.60.1"
 cc = "1.0.73"
-semver = "1.0.10"
+semver = "1.0.13"

--- a/dart-api-dl/Cargo.toml
+++ b/dart-api-dl/Cargo.toml
@@ -7,6 +7,6 @@ license = "Apache-2.0"
 [dependencies]
 dart-api-dl-sys = { package = "xayn-dart-api-dl-sys", version = "0.3.0" }
 displaydoc = "0.2.3"
-once_cell = "1.12.0"
+once_cell = "1.13.0"
 static_assertions = "1.1.0"
-thiserror = "1.0.31"
+thiserror = "1.0.32"

--- a/dart-api-dl/src/cobject/type_enums.rs
+++ b/dart-api-dl/src/cobject/type_enums.rs
@@ -73,7 +73,7 @@ impl_from_for_pseudo_enums! {
 /// - It was added in a newer Dart VM version.
 /// - It's the `Dart_CObject_kUnsupported` type.
 /// - It's the `Dart_CObject_kNumberOfTypes` type.
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Eq, Error, PartialEq)]
 #[error("UnknownCObjectType: {:?}", _0)]
 pub struct UnknownCObjectType(pub Dart_CObject_Type);
 

--- a/integration-tests-bindings/Cargo.toml
+++ b/integration-tests-bindings/Cargo.toml
@@ -6,8 +6,8 @@ license = "Apache-2.0"
 
 [dependencies]
 dart-api-dl = { package = "xayn-dart-api-dl", version = "0.3.0" }
-once_cell = "1.12.0"
-thiserror = "1.0.31"
+once_cell = "1.13.0"
+thiserror = "1.0.32"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.61.0"
+channel = "1.62.1"
 profile = "default"

--- a/update-lib/Cargo.toml
+++ b/update-lib/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-semver = "1.0.10"
+semver = "1.0.13"
 toml_edit = "0.14.4"


### PR DESCRIPTION
**References**

- [TY-3100]

**Summary**

- update rust toolchain to `1.62.1`/`nightly-2022-07-16`
- fix clippy lints
- update rust dependencies
